### PR TITLE
[CI] Adding Python 3.8, 3.9 and 3.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,21 +1,21 @@
-name: Run Tests
+name: Build and test
 
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 jobs:
-  tests:
+  standard:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        os: ["windows-2019", "windows-2022"]
+        python-version: ["3.10", "3.11", "3.12"]
 
-    name: Python ${{ matrix.python-version }} / ${{ matrix.os }}
+    name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
 
@@ -35,4 +35,4 @@ jobs:
 
     - name: Run package tests
       run: |
-        python -m unittest discover sw_core_data_types\src\sw_core
+        python -m unittest discover --verbose sw_core_data_types\src\sw_core

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "The Studio W developments core package"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 classifiers = ["Programming Language :: Python :: 3"]
 dependencies = ["numpy"]
 


### PR DESCRIPTION
Adding Python 3.8, 3.9 and 3.10 to the test suite adn relaxing requirements.
Adding windows 2019